### PR TITLE
add custom config for tmate sessions

### DIFF
--- a/config.el
+++ b/config.el
@@ -83,3 +83,19 @@
 
 (use-package! ii-pair)
 (use-package! ox-gfm)
+(use-package! ii-pair
+  :config
+  (setq org-babel-default-header-args:tmate
+  `((:results . "silent")
+    (:session . ,(if (getenv "CODER_WORKSPACE_NAME")
+                    (getenv "CODER_WORKSPACE_NAME")
+                  "org"))
+    (:window . "ii")
+    (:dir . ".")
+    (:socket .
+             ;; if emacs is run within tmux/tmate
+             ;; let's go ahead and use our existing socket
+             ;; otherwise we are likely wanting to launch our own
+             ,(if (getenv "TMUX")
+                 (car (split-string (getenv "TMUX") ","))
+               (symbol-value nil))))))

--- a/config.el
+++ b/config.el
@@ -81,7 +81,6 @@
 ;; You can also try 'gd' (or 'C-c c d') to jump to their definition and see how
 ;; they are implemented.
 
-(use-package! ii-pair)
 (use-package! ox-gfm)
 (use-package! ii-pair
   :config


### PR DESCRIPTION
this is working to overwrite the custom header args of the ii-pair tmate src blocks