### PR TITLE
add helper function for org-mode

### DIFF
--- a/config.el
+++ b/config.el
@@ -147,3 +147,12 @@
         (server :default "localhost")
         (port :default 5432)))
   )
+;; Add helper functions
+
+(defun ii-ob-clear-all-results ()
+  "Clear all result blocks in current org-mode buffer."
+  (interactive)
+  (save-excursion
+    (goto-char (point-min))
+    (while (org-babel-next-src-block)
+      (org-babel-remove-result))))


### PR DESCRIPTION
Added a function for clearing an org buffer of its results blocks.  It's useful to be able to run this before a commit so that an org template does not have pre-populated results