### PR TITLE
remove sql defaults for consistent output

### DIFF
--- a/config.el
+++ b/config.el
@@ -129,7 +129,7 @@
 (after! org
   (setq org-babel-default-header-args
       '((:session . "none")
-        (:results . "replace code")
+        (:results . "replace")
         (:comments . "org")
         (:exports . "both")
         (:eval . "never-export")
@@ -138,9 +138,8 @@
       '((:results . "output code verbatim replace")
         (:wrap . "example")))
   (setq org-babel-default-header-args:sql-mode
-      '((:results . "replace code")
-        (:product . "postgres")
-        (:wrap . "SRC example")))
+      '((:results . "replace verbatim")
+        (:product . "postgres")))
  (setq sql-postgres-login-params
       '((user :default "postgres")
         (database :default "postgres")


### PR DESCRIPTION
in my local doom my sql results have a different color and colons on the side.  hh liked the look of this.  Comparing the header args, my local config does not wrap the results in an example block and does not give the results as code. 

I removed the code from the main result blocks and added verbatim to the sql ones to try to get a more consistent look in our blocks