### PR TITLE
Update config.el with sql hook

### DIFF
--- a/config.el
+++ b/config.el
@@ -140,6 +140,11 @@
       (concat org-babel-tmux-session-prefix
         (if (string-equal "" session) (alist-get :session org-babel-default-header-args:tmux) session))))
   )
+(after! ob-sql-mode
+        ;; make sql statements a one-liner before being sent to sql engine
+  (setq org-babel-sql-mode-pre-execute-hook
+        (lambda (body params)
+          (s-replace "\n" " " body))))
 (after! org
   (setq org-babel-default-header-args
       '((:session . "none")
@@ -178,3 +183,4 @@
     (org-ai-install-yasnippets)
     (setq org-ai-openai-api-token (getenv "OPENAI_API_TOKEN"))
   )
+


### PR DESCRIPTION
This adds a hook before the sql gets executed in source block, changing all the newlines to spaces so that the statement is on a single line.  This is a workaround for an issue where sometimes multiline statements don't have their results show in the org file.