### PR TITLE
Add docker / Dockerfile support

### DIFF
--- a/init.el
+++ b/init.el
@@ -89,7 +89,7 @@
        ;;biblio            ; Writes a PhD for you (citation needed)
        debugger            ; FIXME stepping through code, to help you add bugs
        direnv
-       ;;docker
+       (docker +lsp)
        editorconfig        ; let someone else argue about tabs vs spaces
        ;; ein                 ; tame Jupyter notebooks with emacs
        (eval +overlay)     ; run code, run (also, repls)

--- a/init.el
+++ b/init.el
@@ -89,7 +89,8 @@
        ;;biblio            ; Writes a PhD for you (citation needed)
        debugger            ; FIXME stepping through code, to help you add bugs
        direnv
-       (docker +lsp)
+       (docker +lsp)       ; +lsp requires docker-langserver from https://emacs-lsp.github.io/lsp-mode/page/lsp-dockerfile/:
+                           ; npm install -g dockerfile-language-server-nodejs
        editorconfig        ; let someone else argue about tabs vs spaces
        ;; ein                 ; tame Jupyter notebooks with emacs
        (eval +overlay)     ; run code, run (also, repls)


### PR DESCRIPTION
https://emacs-lsp.github.io/lsp-mode/page/lsp-dockerfile/

Also support lsp from https://emacs-lsp.github.io/lsp-mode/page/lsp-dockerfile/: 

This will require installing `docker-langserver`:
```npm install -g dockerfile-language-server-nodejs```