### PR TITLE
Doom failing to start with debugger enabled

### DIFF
--- a/init.el
+++ b/init.el
@@ -87,7 +87,7 @@
        :tools
        ;;ansible
        ;;biblio            ; Writes a PhD for you (citation needed)
-       debugger            ; FIXME stepping through code, to help you add bugs
+       ;;debugger          ; FIXME stepping through code, to help you add bugs
        direnv
        ;;docker
        editorconfig        ; let someone else argue about tabs vs spaces


### PR DESCRIPTION
Removing `debugger` from current [init.el](https://github.com/ii/doom-config/blob/042ba02ea85178985726970371795decd9f931db/init.el#L90)   due to the following error message

![broken-emacs-config](https://github.com/user-attachments/assets/9db15bf0-38dd-4b64-9126-ef4cd3499028)
