### PR TITLE
Add default nerd-icons fonts

### DIFF
--- a/config.el
+++ b/config.el
@@ -196,6 +196,10 @@
        (org-mark-subtree)
        (ii-ob-clear-results-region (point) (mark))))
 
+;; Install fonts
+(after! nerd-icons
+  (nerd-icons-install-fonts :yes))
+
 ;; Power up Org Experience
 (after! org
   (setq org-tags-column -80)

--- a/packages.el
+++ b/packages.el
@@ -72,6 +72,9 @@
    :local-repo "org-ai"
    :files ("*.el" "README.md" "snippets")))
 
+;; Add fonts
+(package! nerd-icons)
+
 ;;--------------
 ;; Pairing tools
 ;;--------------


### PR DESCRIPTION
We were installing the fonts using the default `--fonts` as part of building iipod

```
RUN yes | ~/.config/emacs/bin/doom install --env --fonts
```
which used the [following](https://github.com/doomemacs/doomemacs/blob/7bdf7cf7c0bbaa76d983ef8930bfe90cd3c8a85e/lisp/cli/install.el#L124-L127)
```
           (require 'all-the-icons)
           (let ((window-system (cond (IS-MAC 'ns)
                                      (IS-LINUX 'x))))
             (all-the-icons-install-fonts 'yes))))
```
but now doesn't exist now due to this refactor in https://github.com/doomemacs/doomemacs/pull/7411